### PR TITLE
Depend on GPUArraysCore, etc

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,11 @@
 name = "OneHotArrays"
 uuid = "0b1bfda6-eb8a-41d2-88d8-f5af5cad476f"
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
+GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MLUtils = "f1d291b0-491e-4a28-83b9-f70985020b54"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
@@ -14,17 +14,18 @@ NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 Adapt = "3.0"
 CUDA = "3.8"
 ChainRulesCore = "1.13"
-GPUArrays = "8.2.1"
+GPUArraysCore = "0.1.0"
 MLUtils = "0.2"
 NNlib = "0.8"
 Zygote = "0.6.35"
 julia = "1.6"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Test", "CUDA", "Random", "Zygote"]
+test = ["Test", "CUDA", "JLArrays", "Random", "Zygote"]

--- a/src/OneHotArrays.jl
+++ b/src/OneHotArrays.jl
@@ -2,7 +2,7 @@ module OneHotArrays
 
 using Adapt
 using ChainRulesCore
-using GPUArrays
+using GPUArraysCore
 using LinearAlgebra
 using MLUtils 
 using NNlib

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,5 @@ else
 end
 
 @testset "GPUArrays" begin
-  @test cu(rand(3)) .+ 1 isa CuArray
   include("gpu.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,23 +17,17 @@ using Zygote
 import CUDA
 if CUDA.functional()
   using CUDA  # exports CuArray, etc
+  CUDA.allowscalar(false)
   @info "starting CUDA tests"
 else
-  @info "CUDA not functional, testing via GPUArrays"
-  using GPUArrays
-  GPUArrays.allowscalar(false)
-
-  # GPUArrays provides a fake GPU array, for testing
-  jl_file = normpath(joinpath(pathof(GPUArrays), "..", "..", "test", "jlarray.jl"))
-  using Random  # loaded within jl_file
-  include(jl_file)
-  using .JLArrays
+  @info "CUDA not functional, testing with JLArrays instead"
+  using JLArrays  # fake GPU array, for testing
+  JLArrays.allowscalar(false)
   cu = jl
   CuArray{T,N} = JLArray{T,N}
 end
 
-@test cu(rand(3)) .+ 1 isa CuArray
-
 @testset "GPUArrays" begin
+  @test cu(rand(3)) .+ 1 isa CuArray
   include("gpu.jl")
 end


### PR DESCRIPTION
This cuts loading time from 2.06s to 0.42s, by using GPUArraysCore not GPUArrays.

It also uses the now-registered JLArrays for testing, instead of grabbing the module from within GPUArrays. 

