### PR TITLE
minor doc additions and fixes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,7 +64,7 @@ jobs:
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
       - run: |
-          julia --project=docs/ -e '
+          julia --color=yes --project=docs/ -e '
             using OneHotArrays
             # using Pkg; Pkg.activate("docs")
             using Documenter

--- a/src/array.jl
+++ b/src/array.jl
@@ -26,8 +26,8 @@ const OneHotVector{T, L} = OneHotArray{T, L, 0, 1, T}
 """
     OneHotMatrix{T, L, I} = OneHotArray{T, L, 1, 2, I}
 
-Constructed by [`onehotbatch`](@ref). Parameter `I` is the type of the underlying
-storage, `T` is its eltype and `L` is the length of labels.
+A one-hot matrix (with `L` labels) typically constructed using [`onehotbatch`](@ref).
+Stored efficiently as a vector of indices with type `I` and eltype `T`.
 """
 const OneHotMatrix{T, L, I} = OneHotArray{T, L, 1, 2, I}
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -1,7 +1,10 @@
 """
     OneHotArray{T, L, N, M, I} <: AbstractArray{Bool, M}
 
-Constructed by [`onehot`](@ref) and [`onehotbatch`](@ref).
+A one-hot `M`-dimensional array with `L` labels (i.e. `size(A, 1) == L` and `sum(A, dims=1) == 1`)
+stored as a compact `N == M-1`-dimensional array of indices.
+
+Typically constructed by [`onehot`](@ref) and [`onehotbatch`](@ref).
 Parameter `I` is the type of the underlying storage, and `T` its eltype.
 """
 struct OneHotArray{T<:Integer, L, N, var"N+1", I<:Union{T, AbstractArray{T, N}}} <: AbstractArray{Bool, var"N+1"}

--- a/src/array.jl
+++ b/src/array.jl
@@ -18,8 +18,8 @@ _indices(x::Base.ReshapedArray{<: Any, <: Any, <: OneHotArray}) =
 """
     OneHotVector{T, L} = OneHotArray{T, L, 0, 1, T}
 
-Constructed by [`onehot`](@ref). Parameter `T` is the type of the underlying
-storage and `L` is the length of labels.
+A one-hot vector with `L` labels (i.e. `length(A) == L` and `count(A) == 1`) typically constructed by [`onehot`](@ref).
+Stored efficiently as a single index of type `T`, usually `UInt32`.
 """
 const OneHotVector{T, L} = OneHotArray{T, L, 0, 1, T}
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -1,7 +1,7 @@
 """
-    OneHotArray{T,L,N,M,I} <: AbstractArray{Bool,M}
+    OneHotArray{T, L, N, M, I} <: AbstractArray{Bool, M}
 
-These are constructed by [`onehot`](@ref) and [`onehotbatch`](@ref).
+Constructed by [`onehot`](@ref) and [`onehotbatch`](@ref).
 Parameter `I` is the type of the underlying storage, and `T` its eltype.
 """
 struct OneHotArray{T<:Integer, L, N, var"N+1", I<:Union{T, AbstractArray{T, N}}} <: AbstractArray{Bool, var"N+1"}
@@ -15,12 +15,23 @@ _indices(x::OneHotArray) = x.indices
 _indices(x::Base.ReshapedArray{<: Any, <: Any, <: OneHotArray}) =
   reshape(parent(x).indices, x.dims[2:end])
 
+"""
+    OneHotVector{T, L} = OneHotArray{T, L, 0, 1, T}
+
+Constructed by [`onehot`](@ref). Parameter `T` is the type of the underlying
+storage and `L` is the length of labels.
+"""
 const OneHotVector{T, L} = OneHotArray{T, L, 0, 1, T}
+
+"""
+    OneHotMatrix{T, L, I} = OneHotArray{T, L, 1, 2, I}
+
+Constructed by [`onehotbatch`](@ref). Parameter `I` is the type of the underlying
+storage, `T` is its eltype and `L` is the length of labels.
+"""
 const OneHotMatrix{T, L, I} = OneHotArray{T, L, 1, 2, I}
 
-@doc @doc(OneHotArray)
 OneHotVector(idx, L) = OneHotArray(idx, L)
-@doc @doc(OneHotArray)
 OneHotMatrix(indices, L) = OneHotArray(indices, L)
 
 # use this type so reshaped arrays hit fast paths

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -1,7 +1,7 @@
 """
     onehot(x, labels, [default])
 
-Return a `OneHotVector` which is roughly a sparse representation of `x .== labels`.
+Returns a [`OneHotVector`](@ref) which is roughly a sparse representation of `x .== labels`.
 
 Instead of storing say `Vector{Bool}`, it stores the index of the first occurrence 
 of `x` in `labels`. If `x` is not found in labels, then it either returns `onehot(default, labels)`,
@@ -50,7 +50,7 @@ _findval(val, labels::Tuple{}, i::Integer) = nothing
 """
     onehotbatch(xs, labels, [default])
 
-Returns a `OneHotMatrix` where `k`th column of the matrix is [`onehot(xs[k], labels)`](@ref onehot).
+Returns a [`OneHotMatrix`](@ref) where `k`th column of the matrix is [`onehot(xs[k], labels)`](@ref onehot).
 This is a sparse matrix, which stores just a `Vector{UInt32}` containing the indices of the
 nonzero elements.
 


### PR DESCRIPTION
I think `OneHotMatrix` and `OneHotVector` should have their own docstrings as they are present as well as referenced in the manual.