### PR TITLE
Store number of labels as a field

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OneHotArrays"
 uuid = "0b1bfda6-eb8a-41d2-88d8-f5af5cad476f"
-version = "0.1.1"
+version = "0.2.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/array.jl
+++ b/src/array.jl
@@ -65,7 +65,7 @@ function Base.getindex(x::OneHotArray{<:Any, N}, i::Integer, I::Vararg{Any, N}) 
   return x.indices[I...] .== i
 end
 
-function Base.getindex(x::OneHotArray, ::Colon, I::Union{Colon, <:Integer}...)
+function Base.getindex(x::OneHotArray{<:Any, N}, ::Colon, I::Vararg{Any, N}) where N
   @boundscheck checkbounds(x, :, I...)
   return OneHotArray(x.indices[I...], x.nlabels)
 end

--- a/src/array.jl
+++ b/src/array.jl
@@ -60,13 +60,11 @@ end
 
 Base.size(x::OneHotArray) = (x.nlabels, size(x.indices)...)
 
-function Base.getindex(x::OneHotArray{<:Any, N}, i::Integer, I::Vararg{Any, N}) where N
-  @boundscheck checkbounds(x, i, I...)
+function Base.getindex(x::OneHotArray{<:Any, N}, i::Int, I::Vararg{Int, N}) where N
+  @boundscheck 1 <= i <= x.nlabels
   return x.indices[I...] .== i
 end
-
 function Base.getindex(x::OneHotArray{<:Any, N}, ::Colon, I::Vararg{Any, N}) where N
-  @boundscheck checkbounds(x, :, I...)
   return OneHotArray(x.indices[I...], x.nlabels)
 end
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -106,56 +106,12 @@ end
 _onehot_bool_type(::OneHotLike{<:Any, <:Any, var"N+1", <:Union{Integer, AbstractArray}}) where {var"N+1"} = Array{Bool, var"N+1"}
 _onehot_bool_type(::OneHotLike{<:Any, <:Any, var"N+1", <:AbstractGPUArray}) where {var"N+1"} = AbstractGPUArray{Bool, var"N+1"}
 
-_chk_cat_dim(d, x, y) = (x == y) ? x :
-  throw(DimensionMismatch("mismatch in dimension $d (expected $x got $y)"))
-
-_cat_size(iscatdims, dims::NTuple{N}) where N = dims
-function _cat_size(iscatdims, dims::NTuple{N}, x) where N
-  dims = ntuple(Val(N)) do i
-    d = dims[i]
-    sx = size(x, i)
-    iscatdims[i] ? d + sx : _chk_cat_dim(i, d, sx)
-  end
-
-  return dims
-end
-function _cat_size(iscatdims, dims::NTuple{N}, x, tail...) where N
-  dims = _cat_size(iscatdims, dims, x)
-  return _cat_size(iscatdims, dims, tail...)
-end
-
-_cat_similar(::Integer, sz) = zeros(Bool, sz)
-_cat_similar(x, sz) = similar(x, Bool, sz)
-
 _notall_onehot(x::OneHotArray, xs::OneHotArray...) = false
 _notall_onehot(x::OneHotLike, xs::OneHotLike...) = any(x -> !_isonehot(x), (x, xs...))
 
-function _cat_fallback(x::OneHotLike{<:Any, <:Any, N}, xs::OneHotLike...; dims::Int) where N
-  # this is adapted from Base
-  # https://github.com/JuliaLang/julia/blob/5544a0fab7648cfa61fe79cd557a7504a92ec1b5/base/abstractarray.jl#L1730-L1738
-  # invoking the less specialized version of cat results in even worse performance
-  # we really only want to be in this method if dims != 1 and all the labels match
-  # without the number of labels in the type, we can't do this at compile time
-  # so we reimplement some stuff from the less specialized cat
-  catdims = ntuple(in(dims), Val(N))
-  catsize = _cat_size(catdims, size(x), xs...)
-  y = _cat_similar(_indices(x), catsize)
-  offset = ones(Int, N)
-  for xi in (x, xs...)
-    nelements = size(xi)
-    I = ntuple(N) do i
-      catdims[i] ? (offset[i]:(offset[i] + nelements[i] - 1)) : Colon()
-    end
-    y[I...] = xi
-    offset .+= nelements
-  end
-
-  return y
-end
-
 function Base.cat(x::OneHotLike{<:Any, <:Any, N}, xs::OneHotLike...; dims::Int) where N
   if isone(dims) || _notall_onehot(x, xs...)
-    return _cat_fallback(x, xs...; dims = dims)
+    return cat(map(x -> convert(_onehot_bool_type(x), x), (x, xs...))...; dims = dims)
   else
     L = _nlabels(x, xs...)
 
@@ -165,7 +121,7 @@ end
 
 Base.hcat(x::OneHotLike, xs::OneHotLike...) = cat(x, xs...; dims = 2)
 Base.vcat(x::OneHotLike, xs::OneHotLike...) =
-  _cat_fallback(x, xs...; dims = 1)
+  vcat(map(x -> convert(_onehot_bool_type(x), x), (x, xs...))...)
 
 # optimized concatenation for matrices and vectors of same parameters
 Base.hcat(x::OneHotMatrix, xs::OneHotMatrix...) =

--- a/src/array.jl
+++ b/src/array.jl
@@ -65,7 +65,7 @@ function Base.getindex(x::OneHotArray{<:Any, N}, i::Integer, I::Vararg{Any, N}) 
   return x.indices[I...] .== i
 end
 
-function Base.getindex(x::OneHotArray, ::Colon, I::Union{Colon, Integer}...)
+function Base.getindex(x::OneHotArray, ::Colon, I::Union{Colon, <:Integer}...)
   @boundscheck checkbounds(x, :, I...)
   return OneHotArray(x.indices[I...], x.nlabels)
 end
@@ -100,10 +100,10 @@ _onehot_bool_type(::OneHotLike{<:Any, <:Any, var"N+1", <:Union{Integer, Abstract
 _onehot_bool_type(::OneHotLike{<:Any, <:Any, var"N+1", <:AbstractGPUArray}) where {var"N+1"} = AbstractGPUArray{Bool, var"N+1"}
 
 function Base.cat(x::OneHotLike, xs::OneHotLike...; dims::Int)
-  L = _check_nlabels(x, xs...)
   if isone(dims) || any(x -> !_isonehot(x), (x, xs...))
     return cat(map(x -> convert(_onehot_bool_type(x), x), (x, xs...))...; dims = dims)
   else
+    L = _check_nlabels(x, xs...)
     return OneHotArray(cat(_indices(x), _indices.(xs)...; dims = dims - 1), L)
   end
 end

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1,12 +1,12 @@
-function Base.:(*)(A::AbstractMatrix, B::OneHotLike{<:Any, L}) where L
+function Base.:(*)(A::AbstractMatrix, B::OneHotLike)
   _isonehot(B) || return invoke(*, Tuple{AbstractMatrix, AbstractMatrix}, A, B)
-  size(A, 2) == L || throw(DimensionMismatch("Matrix column must correspond with OneHot size: $(size(A, 2)) != $L"))
+  size(A, 2) == size(B, 1) || throw(DimensionMismatch("Matrix column must correspond with OneHot size: $(size(A, 2)) != $(size(B, 1))"))
   return A[:, onecold(B)]
 end
   
-function Base.:(*)(A::AbstractMatrix, B::OneHotLike{<:Any, L, 1}) where L
+function Base.:(*)(A::AbstractMatrix, B::OneHotLike{<:Any, 1})
   _isonehot(B) || return invoke(*, Tuple{AbstractMatrix, AbstractMatrix}, A, B)
-  size(A, 2) == L || throw(DimensionMismatch("Matrix column must correspond with OneHot size: $(size(A, 2)) != $L"))
+  size(A, 2) == size(B, 1) || throw(DimensionMismatch("Matrix column must correspond with OneHot size: $(size(A, 2)) != $(size(B, 1))"))
   return NNlib.gather(A, _indices(B))
 end
 
@@ -18,16 +18,16 @@ end
 
 for wrapper in [:Adjoint, :Transpose]
   @eval begin
-    function Base.:*(A::$wrapper{<:Any, <:AbstractMatrix{T}}, b::OneHotVector{<:Any, L}) where {L, T}
-      size(A, 2) == L ||
-          throw(DimensionMismatch("Matrix column must correspond with OneHot size: $(size(A, 2)) != $L"))
+    function Base.:*(A::$wrapper{<:Any, <:AbstractMatrix{T}}, b::OneHotVector) where T
+      size(A, 2) == length(b) ||
+          throw(DimensionMismatch("Matrix column must correspond with OneHot size: $(size(A, 2)) != $(length(b))"))
 
       return A[:, onecold(b)]
     end
 
-    function Base.:*(A::$wrapper{<:Number, <:AbstractVector{T}}, b::OneHotVector{<:Any, L}) where {L, T}
-      size(A, 2) == L ||
-          throw(DimensionMismatch("Matrix column must correspond with OneHot size: $(size(A, 2)) != $L"))
+    function Base.:*(A::$wrapper{<:Number, <:AbstractVector{T}}, b::OneHotVector) where T
+      size(A, 2) == length(b) ||
+          throw(DimensionMismatch("Matrix column must correspond with OneHot size: $(size(A, 2)) != $(length(b))"))
 
       return A[onecold(b)]
     end

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -135,6 +135,7 @@ function onecold(y::AbstractArray, labels = 1:size(y, 1))
 end
 
 _fast_argmax(x::AbstractArray) = dropdims(argmax(x; dims = 1); dims = 1)
+_fast_argmax(x::OneHotArray) = _indices(x)
 function _fast_argmax(x::OneHotLike)
   if _isonehot(x)
     return _indices(x)

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -31,13 +31,13 @@ julia> hcat(αβγ...)  # preserves sparsity
 function onehot(x, labels)
   i = _findval(x, labels)
   isnothing(i) && error("Value $x is not in labels")
-  OneHotVector{UInt32, length(labels)}(i)
+  OneHotVector{UInt32}(i, length(labels))
 end
 
 function onehot(x, labels, default)
   i = _findval(x, labels)
   isnothing(i) && return onehot(default, labels)
-  OneHotVector{UInt32, length(labels)}(i)
+  OneHotVector{UInt32}(i, length(labels))
 end
 
 _findval(val, labels) = findfirst(isequal(val), labels)
@@ -147,4 +147,4 @@ ChainRulesCore.@non_differentiable onehot(::Any...)
 ChainRulesCore.@non_differentiable onehotbatch(::Any...)
 ChainRulesCore.@non_differentiable onecold(::Any...)
 
-ChainRulesCore.@non_differentiable (::Type{<:OneHotArray})(indices::Any, L::Integer)
+ChainRulesCore.@non_differentiable (::Type{<:OneHotArray})(indices::Any, L::Int)

--- a/test/array.jl
+++ b/test/array.jl
@@ -15,7 +15,7 @@ end
   # vector indexing
   @test ov[3] == (ov.indices == 3)
   @test ov[:] == ov
-  
+
   # matrix indexing
   @test om[3, 3] == (om.indices[3] == 3)
   @test om[:, 3] == OneHotVector(om.indices[3], 10)

--- a/test/onehot.jl
+++ b/test/onehot.jl
@@ -26,6 +26,12 @@
   @test onecold(onehot(0.0, floats)) == 1
   @test onecold(onehot(-0.0, floats)) == 2  # as it uses isequal
   @test onecold(onehot(Inf, floats)) == 5
+
+  # inferrabiltiy tests
+  @test @inferred(onehot(20, 10:10:30)) == [false, true, false]
+  @test @inferred(onehot(40, (10,20,30), 20)) == [false, true, false]
+  @test @inferred(onehotbatch([20, 10], 10:10:30)) == Bool[0 1; 1 0; 0 0]
+  @test @inferred(onehotbatch([40, 10], (10,20,30), 20)) == Bool[0 1; 1 0; 0 0]
 end
 
 @testset "onecold" begin


### PR DESCRIPTION
As suggested on Slack, storing the number of labels as a field instead of in the type results in type stable code. The [original PR](https://github.com/FluxML/Flux.jl/pull/1447) that I based my overhaul of one-hot arrays on mentions memory consumption as the main reason for keeping the label in the type. While it is certainly significantly less memory than the _old, old_ Flux implementation, compared to this PR, the overhead is constant (8 bytes).

I benchmarked to see if storing in the type resulted in downstream performance improvements (a reason to reject this PR). The results are mixed, but I think any measurable performance loss is due to a slower path being taken for indexing like `ov[1:3]`. I haven't figured how to fix this, but I think it is fixable. I don't think the performance loss is fundamental to where the number of label info is stored.

<details>
<summary> Benchmarking results and code </summary>

| Test target | Code | `@btime` for main | `@btime` for PR |
|:------------|:-----|:------------------|:----------------|
| `getindex` | `ov[1]` | 2.125 ns (0 allocations: 0 bytes) | 3.041 ns (0 allocations: 0 bytes) |
| `getindex` | `ov[1:3]` | 18.579 ns (1 allocation: 64 bytes) | 21.523 ns (1 allocation: 64 bytes) |
| `getindex` | `om[1, 2]` | 2.083 ns (0 allocations: 0 bytes) | 3.000 ns (0 allocations: 0 bytes) |
| `getindex` | `om[1:2, 3]` | 20.979 ns (1 allocation: 64 bytes) | 21.648 ns (1 allocation: 64 bytes) |
| `getindex` | `oa[1, 2, 3]` | 2.416 ns (0 allocations: 0 bytes) | 3.000 ns (0 allocations: 0 bytes) |
| `getindex` | `oa[1, :, 3]` | 201.261 ns (6 allocations: 256 bytes) | 24.556 ns (1 allocation: 64 bytes) |
| `getindex` | `oa[:, :, :]` | 2.125 ns (0 allocations: 0 bytes) | 2.125 ns (0 allocations: 0 bytes) |
| `size` | `length(ov)` | 1.167 ns (0 allocations: 0 bytes) | 2.125 ns (0 allocations: 0 bytes) |
| `size` | `size(oa)` | 2.083 ns (0 allocations: 0 bytes) | 2.084 ns (0 allocations: 0 bytes) |
| concat | `vcat(ov, ov2)` | 31.816 ns (1 allocation: 80 bytes) | 83.678 ns (3 allocations: 208 bytes) |
| concat | `hcat(ov, ov)` | 243.719 ns (2 allocations: 96 bytes) | 17.994 ns (1 allocation: 80 bytes) |
| concat | `hcat(om, om)` | 258.048 ns (2 allocations: 160 bytes) | 31.061 ns (1 allocation: 144 bytes) |
| concat | `vcat(om, om2)` | 186.143 ns (1 allocation: 160 bytes) | 272.052 ns (3 allocations: 384 bytes) |
| concat | `cat(oa, oa, oa; dims = 2)` | 2.093 μs (51 allocations: 1.98 KiB) | 2.528 μs (64 allocations: 2.66 KiB) |
| broadcast | `2 .* om` | 42.886 ns (1 allocation: 496 bytes) | 53.245 ns (1 allocation: 496 bytes) |
| broadcast | `om .* om .+ ov` | 72.852 ns (1 allocation: 496 bytes) | 116.178 ns (1 allocation: 496 bytes) |
| `argmax` | `argmax(om; dims = 1)`  | 34.876 ns (3 allocations: 240 bytes) | 35.211 ns (3 allocations: 240 bytes) |
| `argmax` | `argmax(oa; dims = 2)`  | 3.391 μs (28 allocations: 3.23 KiB) | 3.828 μs (28 allocations: 3.12 KiB) |
| onehot | `onehot((rand(1:10)), (1:10))` | 744.877 ns (8 allocations: 368 bytes) | 3.000 ns (0 allocations: 0 bytes) |
| onehot | `onehotbatch((rand(1:10, 50)), (1:10))` | 628.188 ns (4 allocations: 512 bytes) | 441.919 ns (4 allocations: 528 bytes) |
| onecold | `onecold(ov)` | 2.778 μs (19 allocations: 1.69 KiB) | 2.602 μs (19 allocations: 1.58 KiB) |
| onecold | `onecold(om)` | 22.590 ns (1 allocation: 96 bytes) | 22.757 ns (1 allocation: 96 bytes) |
| onecold | `onecold(oa)` | 34.743 ns (1 allocation: 256 bytes) | 34.660 ns (1 allocation: 256 bytes) |
| matmul | `(rand(5, 10)) * om` | 55.752 ns (1 allocation: 256 bytes) | 55.923 ns (1 allocation: 256 bytes) |
| matmul | `(rand(5, 10)) * ov` | 3.026 μs (28 allocations: 1.92 KiB) | 2.847 μs (28 allocations: 1.81 KiB) |
| matmul | `(rand(5, 5)) * adjoint(om)` | 53.879 ns (1 allocation: 496 bytes) | 53.583 ns (1 allocation: 496 bytes) |

Created by running:
```julia
using OneHotArrays
using BenchmarkTools

ov = OneHotVector(rand(1:10), 10)
ov2 = OneHotVector(rand(1:11), 11)
om = OneHotMatrix(rand(1:10, 5), 10)
om2 = OneHotMatrix(rand(1:11, 5), 11)
oa = OneHotArray(rand(1:10, 5, 5), 10)

@info "getindex"
@btime $ov[1]
@btime $ov[1:3]
@btime $om[1, 2]
@btime $om[1:2, 3]
@btime $oa[1, 2, 3]
@btime $oa[1, :, 3]
@btime $oa[:, :, :]

@info "size"
@btime length($ov)
@btime size($oa)

@info "concat"
@btime vcat($ov, $ov2)
@btime hcat($ov, $ov)
@btime hcat($om, $om)
@btime vcat($om, $om2)
@btime cat($oa, $oa, $oa; dims = 2)

@info "broadcast"
@btime 2 .* $om
@btime $om .* $om .+ $ov

@info "argmax"
@btime argmax($om; dims = 1)
@btime argmax($oa; dims = 2)

@info "onehot"
@btime onehot($(rand(1:10)), $(1:10))
@btime onehotbatch($(rand(1:10, 50)), $(1:10))

@info "onecold"
@btime onecold($ov)
@btime onecold($om)
@btime onecold($oa)

@info "matmul"
@btime $(rand(5, 10)) * $om
@btime $(rand(5, 10)) * $ov
@btime $(rand(5, 5)) * adjoint($om)
;
```

</details>