### PR TITLE
Add some checks to `onecold`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OneHotArrays"
 uuid = "0b1bfda6-eb8a-41d2-88d8-f5af5cad476f"
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -129,7 +129,7 @@ julia> onecold([ 1  0  0  1  0  1  0  1  0  0  1
 function onecold(y::AbstractVector, labels = 1:length(y))
   nl = length(labels)
   ny = length(y)
-  nl == ny || throw(DimensionMismatch("onecold got $nl lables for a vector of length $ny, these must agree"))
+  nl == ny || throw(DimensionMismatch("onecold got $nl labels for a vector of length $ny, these must agree"))
   ymax, i = findmax(y)
   ymax isa Number && isnan(ymax) && throw(ArgumentError("maximum value found by onecold is $ymax"))
   labels[i]
@@ -137,7 +137,7 @@ end
 function onecold(y::AbstractArray, labels = 1:size(y, 1))
   nl = length(labels)
   ny = size(y, 1)
-  nl == ny || throw(DimensionMismatch("onecold got $nl lables for an array with size(y, 1) == $ny, these must agree"))
+  nl == ny || throw(DimensionMismatch("onecold got $nl labels for an array with size(y, 1) == $ny, these must agree"))
   indices = _fast_argmax(y)
   xs = isbits(labels) ? indices : collect(indices) # non-bit type cannot be handled by CUDA
 

--- a/src/onehot.jl
+++ b/src/onehot.jl
@@ -126,8 +126,18 @@ julia> onecold([ 1  0  0  1  0  1  0  1  0  0  1
 "abeacadabea"
 ```
 """
-onecold(y::AbstractVector, labels = 1:length(y)) = labels[argmax(y)]
+function onecold(y::AbstractVector, labels = 1:length(y))
+  nl = length(labels)
+  ny = length(y)
+  nl == ny || throw(DimensionMismatch("onecold got $nl lables for a vector of length $ny, these must agree"))
+  ymax, i = findmax(y)
+  ymax isa Number && isnan(ymax) && throw(ArgumentError("maximum value found by onecold is $ymax"))
+  labels[i]
+end
 function onecold(y::AbstractArray, labels = 1:size(y, 1))
+  nl = length(labels)
+  ny = size(y, 1)
+  nl == ny || throw(DimensionMismatch("onecold got $nl lables for an array with size(y, 1) == $ny, these must agree"))
   indices = _fast_argmax(y)
   xs = isbits(labels) ? indices : collect(indices) # non-bit type cannot be handled by CUDA
 

--- a/test/onehot.jl
+++ b/test/onehot.jl
@@ -52,6 +52,10 @@ end
   cold = onecold(hot, labels)
 
   @test cold == data
+
+  @test_throws DimensionMismatch onecold([0.3, 0.2], (:a, :b, :c))
+  @test_throws DimensionMismatch onecold([0.3, 0.2, 0.5, 0.99], (:a, :b, :c))
+  @test_throws ArgumentError onecold([0.3, NaN, 0.5], (:a, :b, :c))
 end
 
 @testset "onehotbatch indexing" begin


### PR DESCRIPTION
Closes #22 by checking length.

For `onecold` acting on a matrix, I'm not sure whether checking for NaN will cause issues on GPUs, so I left it out.