### PR TITLE
Add axis permutedims

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -1,8 +1,8 @@
 """
     OneHotArray{T, N, M, I} <: AbstractArray{Bool, M}
-    OneHotArray(indices, L)
+    OneHotArray(indices, L, [axis=1])
 
-A one-hot `M`-dimensional array with `L` labels (i.e. `size(A, 1) == L` and `sum(A, dims=1) == 1`)
+A one-hot `M`-dimensional array with `L` labels (i.e. `size(A, axis) == L` and `sum(A, dims=axis) == 1`)
 stored as a compact `N == M-1`-dimensional array of indices.
 
 Typically constructed by [`onehot`](@ref) and [`onehotbatch`](@ref).
@@ -15,7 +15,10 @@ end
 OneHotArray{T, N, I}(indices, L::Int) where {T, N, I} = OneHotArray{T, N, N+1, I}(indices, L)
 OneHotArray(indices::T, L::Int) where {T<:Integer} = OneHotArray{T, 0, 1, T}(indices, L)
 OneHotArray(indices::I, L::Int) where {T, N, I<:AbstractArray{T, N}} = OneHotArray{T, N, N+1, I}(indices, L)
-OneHotArray(indices, L, axis::Int) = PermutedDimsArray(OneHotArray(indices, L), [axis, 1])
+function OneHotArray(indices, L, axis::Int)
+  a = collect(1:length(size(indices))+1)
+  PermutedDimsArray(OneHotArray(indices, L), insert!(a, 1, popat!(a, axis)))
+end
 
 _indices(x::OneHotArray) = x.indices
 _indices(x::Base.ReshapedArray{<:Any, <:Any, <:OneHotArray}) =

--- a/test/array.jl
+++ b/test/array.jl
@@ -3,12 +3,14 @@ ov2 = OneHotVector(rand(1:11), 11)
 om = OneHotMatrix(rand(1:10, 5), 10)
 om2 = OneHotMatrix(rand(1:11, 5), 11)
 oa = OneHotArray(rand(1:10, 5, 5), 10)
+oa2 = OneHotArray(rand(1:10, 5, 5), 10, 2)
 
 # sizes
 @testset "Base.size" begin
   @test size(ov) == (10,)
   @test size(om) == (10, 5)
   @test size(oa) == (10, 5, 5)
+  @test size(oa2) == (5, 10, 5)
 end
 
 @testset "Indexing" begin
@@ -32,18 +34,30 @@ end
   @test oa[:, :, :] == oa
   @test oa[:] == reshape(oa, :)
 
+  @test oa2[3, 3, 3] == (oa2.parent.indices[3, 3] == 3)
+  @test oa2[3, :, 3] == OneHotVector(oa2.parent.indices[3, 3], 10)
+  @test oa2[:, 3, 3] == (oa2.parent.indices[:, 3] .== 3)
+  @test oa2[:, 3, :] == (oa2.parent.indices .== 3)
+  @test oa2[3, :, :] == OneHotMatrix(oa2.parent.indices[3, :], 10)
+  @test oa2[:, :, :] == oa2
+  @test oa2[:] == reshape(oa2, :)
+
   # cartesian indexing
   @test oa[CartesianIndex(3, 3, 3)] == oa[3, 3, 3]
+  @test oa2[CartesianIndex(3, 3, 3)] == oa2[3, 3, 3]
 
   # linear indexing
   @test om[11] == om[1, 2]
   @test oa[52] == oa[2, 1, 2]
+  @test oa2[55] == oa2[1, 2, 2]
 
   # bounds checks
   @test_throws BoundsError ov[0]
   @test_throws BoundsError om[2, -1]
   @test_throws BoundsError oa[11, 5, 5]
   @test_throws BoundsError oa[:, :]
+  @test_throws BoundsError oa2[5, 11, 5]
+  @test_throws BoundsError oa2[:, :]
 end
 
 @testset "Concatenating" begin
@@ -63,6 +77,9 @@ end
   @test cat(oa, oa; dims = 3) == OneHotArray(cat(oa.indices, oa.indices; dims = 2), 10)
   @test cat(oa, oa; dims = 3) isa OneHotArray
   @test cat(oa, oa; dims = 1) == cat(collect(oa), collect(oa); dims = 1)
+
+  @test cat(oa2, oa2; dims = 3) == OneHotArray(cat(oa2.parent.indices, oa2.parent.indices; dims = 2), 10, 2)
+  @test cat(oa2, oa2; dims = 2) == cat(collect(oa2), collect(oa2); dims = 2)
 
   # stack
   @test stack([ov, ov]) == hcat(ov, ov)
@@ -96,6 +113,18 @@ end
     @test argmax(r) == argmax(OneHotMatrix(reshape(oa.indices, :), 10))
     @test OneHotArrays._fast_argmax(r) == collect(reshape(oa.indices, :))
   end
+
+  @testset "w/ cat" begin
+    r = reshape(oa2, 10, :)
+    @test vcat(r, r) isa Array{Bool}
+  end
+
+  @testset "w/ argmax" begin
+    oa2p = PermutedDimsArray(oa2, [2,1,3])
+    r = reshape(oa2p, 10, :)
+    @test argmax(r) == argmax(OneHotMatrix(reshape(oa2p.parent.parent.indices, :), 10))
+    @test stack(collect(Tuple.(OneHotArrays._fast_argmax(r))))[1,:] == collect(reshape(oa2p.parent.parent.indices, :))
+  end
 end
 
 @testset "Base.argmax" begin
@@ -106,9 +135,13 @@ end
   @test argmax(om; dims = 2) == argmax(convert(Array{Bool}, om); dims = 2)
   @test argmax(oa; dims = 1) == argmax(convert(Array{Bool}, oa); dims = 1)
   @test argmax(oa; dims = 3) == argmax(convert(Array{Bool}, oa); dims = 3)
+  @test argmax(oa2; dims = 2) == argmax(convert(Array{Bool}, oa2); dims = 2)
+  @test argmax(oa2; dims = 3) == argmax(convert(Array{Bool}, oa2); dims = 3)
 end
 
 @testset "Forward map to broadcast" begin
   @test map(identity, oa) == oa
   @test map(x -> 2 * x, oa) == 2 .* oa
+  @test map(identity, oa2) == oa2
+  @test map(x -> 2 * x, oa2) == 2 .* oa2
 end


### PR DESCRIPTION
This pull request introduces a new feature to OneHotArray: the axis in which the vectors are one-hot can be changed at initialization time.
This is achieved by a new constructor which includes this new axis variable, and returns a OneHotArray wrapped by a PermutedDimsArray.

This way of implementing it does not require any code changes which may be hard to maintain and debug.
The performance degradation I've seen in testing is around 10% when using the wrapped OneHotArray, which I think is reasonable. 
The alternative to this method would be to introduce a new `axis` variable to the struct and change many constructors and functions to get the desired behavior - which I've already done in a separate branch. However it is easier to go the easy route and let it go through field testing than go in the complex route first, which may have various downsides.

See also #35 for further discussion

### PR Checklist

- :ballot_box_with_check:  Tests are added
- :ballot_box_with_check:  Documentation, if applicable
