### PR TITLE
Add compat entry for CUDA 5 for tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OneHotArrays"
 uuid = "0b1bfda6-eb8a-41d2-88d8-f5af5cad476f"
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 
 [compat]
 Adapt = "3.0, 4"
-CUDA = "4"
+CUDA = "4, 5"
 ChainRulesCore = "1.13"
 Compat = "4.2"
 GPUArraysCore = "0.1.0"


### PR DESCRIPTION
Once this is merged and a release is made, https://github.com/FluxML/Flux.jl/pull/2362 should finally be able to be merged!

CUDA tests with CUDA 5.2 are passing locally.