### PR TITLE
Fix GPU `getindex`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OneHotArrays"
 uuid = "0b1bfda6-eb8a-41d2-88d8-f5af5cad476f"
-version = "0.2.7"
+version = "0.2.8"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/array.jl
+++ b/src/array.jl
@@ -80,7 +80,7 @@ Base.similar(x::OneHotArray{<:Any,<:Any,<:Any,<:AbstractArray}, ::Type{T}, size:
   similar(x.indices, T, size)
 
 function Base.copyto!(dst::AbstractArray{T,N}, src::OneHotArray{<:Any,<:Any,N,<:AbstractArray}) where {T,N}
-  size(dst) == size(src) || return invoke(copyto!, Tuple{typeof(dst), AbstractArray{Bool,N}})
+  size(dst) == size(src) || return invoke(copyto!, Tuple{typeof(dst), AbstractArray{Bool,N}}, dst, src)
   dst .= reshape(src.indices, 1, size(src.indices)...) .== (1:src.nlabels)
   return dst
 end

--- a/src/array.jl
+++ b/src/array.jl
@@ -79,13 +79,13 @@ Base.getindex(x::OneHotArray{<:Any, N}, ::Colon, ::Vararg{Colon, N}) where N = x
 Base.similar(x::OneHotArray{<:Any,<:Any,<:Any,<:AbstractArray}, ::Type{T}, size::Base.Dims) where T =
   similar(x.indices, T, size)
 
-function Base.copyto!(dst::AbstractArray{T,N}, src::OneHotArray{<:Any,Nm1,N,<:AbstractArray}) where {T,N,Nm1}
+function Base.copyto!(dst::AbstractArray{T,N}, src::OneHotArray{<:Any,<:Any,N,<:AbstractArray}) where {T,N}
   size(dst) == size(src) || return invoke(copyto!, Tuple{typeof(dst), AbstractArray{Bool,N}})
-  # fill!(dst, false)
-  # setindex!.(eachslice(dst; dims=ntuple(d->d+1, Nm1)), true, src.indices)
-  # setindex!.(Ref(dst), true, src.indices, axes(src.indices)...)
-  dst .= reshape(src.indices, 1, size(src.indices)...) .== (1:src.nlabels)  # this works at REPL!
+  dst .= reshape(src.indices, 1, size(src.indices)...) .== (1:src.nlabels)
   return dst
+end
+function Base.copyto!(dst::Array{T,N}, src::OneHotArray{<:Any,<:Any,N,<:AnyGPUArray}) where {T,N}
+  copyto!(dst, adapt(Array, src))
 end
 
 function Base.showarg(io::IO, x::OneHotArray, toplevel)

--- a/src/array.jl
+++ b/src/array.jl
@@ -66,6 +66,10 @@ function Base.getindex(x::OneHotArray{<:Any, N}, i::Int, I::Vararg{Int, N}) wher
   @boundscheck (1 <= i <= x.nlabels) || throw(BoundsError(x, (i, I...)))
   return x.indices[I...] == i
 end
+function Base.getindex(x::OneHotArray{<:Any, N}, i::Int, I::Vararg{Any, N}) where N
+  @boundscheck (1 <= i <= x.nlabels) || throw(BoundsError(x, (i, I...)))
+  return x.indices[I...] .== i
+end
 function Base.getindex(x::OneHotArray{<:Any, N}, ::Colon, I::Vararg{Any, N}) where N
   return OneHotArray(x.indices[I...], x.nlabels)
 end

--- a/src/array.jl
+++ b/src/array.jl
@@ -64,15 +64,7 @@ Base.size(x::OneHotArray) = (x.nlabels, size(x.indices)...)
 
 function Base.getindex(x::OneHotArray{<:Any, N}, i::Int, I::Vararg{Int, N}) where N
   @boundscheck (1 <= i <= x.nlabels) || throw(BoundsError(x, (i, I...)))
-  return x.indices[I...] .== i
-end
-# the method above is faster on the CPU but will scalar index on the GPU
-# so we define the method below to pass the extra indices directly to GPU array
-function Base.getindex(x::OneHotArray{<:Any, N, <:Any, <:AbstractGPUArray},
-                       i::Int, 
-                       I::Vararg{Any, N}) where N
-  @boundscheck (1 <= i <= x.nlabels) || throw(BoundsError(x, (i, I...)))
-  return x.indices[I...] .== i
+  return x.indices[I...] == i
 end
 function Base.getindex(x::OneHotArray{<:Any, N}, ::Colon, I::Vararg{Any, N}) where N
   return OneHotArray(x.indices[I...], x.nlabels)

--- a/test/array.jl
+++ b/test/array.jl
@@ -38,6 +38,9 @@ end
   # linear indexing
   @test om[11] == om[1, 2]
   @test oa[52] == oa[2, 1, 2]
+  @test copyto!(rand(50,1), om) == reshape(om,:,1)  # hits invoke path
+  @test copyto!(rand(51,1), om)[1:50] == vec(om)
+  @test_throws BoundsError copyto!(rand(49,1), om)
 
   # bounds checks
   @test_throws BoundsError ov[0]

--- a/test/gpu.jl
+++ b/test/gpu.jl
@@ -38,7 +38,9 @@ end
   # These were broken on OneHotArrays v0.2.7
   @test @allowscalar cx[2,2] == x[2,2]
   @test_broken collect(cx) == collect(x)
-  @test_broken convert(AbstractArray{Float32}, cx) isa CuArray{Float32}
+  @test_broken Matrix(cx) == Matrix(x) == collect(x)
+  @test_broken Array{Float32}(cx) == Array{Float32}(x) == collect(x)
+  @test convert(AbstractArray{Float32}, cx) isa CuArray{Float32}
 end
 
 @testset "onehot gpu" begin

--- a/test/gpu.jl
+++ b/test/gpu.jl
@@ -27,9 +27,13 @@ end
   @test cx[:, 1:2] isa OneHotMatrix
   @test cx[:, 1:2].indices isa CuArray
 
-  @test @allowscalar cx[:,1] isa OneHotVector  # needs @allowscalar on v0.2.7
+  @test @allowscalar cx[:,1] isa OneHotVector  # column, needs @allowscalar on v0.2.7
   @test @allowscalar cx[:,1].indices isa Integer
   @test collect(@allowscalar cx[:,end]) == [0,1,0]
+
+  @test cx[2,:] isa CuArray{Bool}  # row, is not onehot!
+  @test sum(cx[2,:]) == 2
+  @test collect(cx[2,:]) == x[2,:]
 
   # These were broken on OneHotArrays v0.2.7
   @test @allowscalar cx[2,2] == x[2,2]
@@ -44,7 +48,7 @@ end
   gA = rand(3, 2) |> cu;
 
   #NOTE: this would require something that can copute gradient... we don't have that here?
-  #@test gradient(A -> sum(A * y), gA)[1] isa CuArray 
+  #@test gradient(A -> sum(A * y), gA)[1] isa CuArray
 
   # some specialized implementations call only mul! and not *, so we must ensure this works
   @test LinearAlgebra.mul!(similar(gA, 3, 3), gA, y) ≈ gA*y

--- a/test/gpu.jl
+++ b/test/gpu.jl
@@ -37,10 +37,11 @@ end
 
   # These were broken on OneHotArrays v0.2.7
   @test @allowscalar cx[2,2] == x[2,2]
-  @test_broken collect(cx) == collect(x)
-  @test_broken Matrix(cx) == Matrix(x) == collect(x)
-  @test_broken Array{Float32}(cx) == Array{Float32}(x) == collect(x)
+  @test collect(cx) == collect(x)
+  @test Matrix(cx) == Matrix(x) == collect(x)
+  @test Array{Float32}(cx) == Array{Float32}(x) == collect(x)
   @test convert(AbstractArray{Float32}, cx) isa CuArray{Float32}
+  @test collect(convert(AbstractArray{Float32}, cx)) == collect(x)
 end
 
 @testset "onehot gpu" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,11 +19,13 @@ import CUDA
 if CUDA.functional()
   using CUDA  # exports CuArray, etc
   CUDA.allowscalar(false)
+  using CUDA: @allowscalar
   @info "starting CUDA tests"
 else
   @info "CUDA not functional, testing with JLArrays instead"
   using JLArrays  # fake GPU array, for testing
   JLArrays.allowscalar(false)
+  using JLArrays: @allowscalar
   cu = jl
   CuArray{T,N} = JLArray{T,N}
 end


### PR DESCRIPTION
Before:
```julia
julia> @allowscalar cx[1,1]
ERROR: MethodError: getindex(::OneHotMatrix{UInt32, JLArray{UInt32, 1}}, ::Int64, ::Int64) is ambiguous.

Candidates:
  getindex(x::OneHotArray{var"#s3", N, var"N+1", I} where {var"#s3", var"N+1", I<:Union{AbstractArray{var"#s3", N}, var"#s3"}}, i::Int64, I::Vararg{Int64, N}) where N
    @ OneHotArrays ~/.julia/packages/OneHotArrays/0JMW1/src/array.jl:65
  getindex(x::OneHotArray{<:Any, N, <:Any, <:GPUArraysCore.AbstractGPUArray}, i::Int64, I::Vararg{Any, N}) where N
    @ OneHotArrays ~/.julia/packages/OneHotArrays/0JMW1/src/array.jl:71

Possible fix, define
  getindex(::OneHotArray{var"#s3", N, <:Any, <:Union{…}} where var"#s3", ::Int64, ::Vararg{Int64, N}) where N

Stacktrace:
 [1] macro expansion
   @ ~/.julia/packages/GPUArraysCore/GMsgk/src/GPUArraysCore.jl:210 [inlined]
 [2] top-level scope
   @ REPL[64]:1
Some type information was truncated. Use `show(err)` to see complete types.

julia> @allowscalar collect(cx)
ERROR: MethodError: getindex(::OneHotMatrix{UInt32, JLArray{UInt32, 1}}, ::Int64, ::Int64) is ambiguous.

julia> x = onehotbatch(rand(1:99, 100), 1:100);

julia> @btime Matrix($x);
  8.958 μs (3 allocations: 10.08 KiB)
```
After:
```julia
julia> @allowscalar cx[1,1]
true

julia> collect(cx)
3×4 Matrix{Bool}:
 1  0  0  0
 0  1  0  1
 0  0  1  0

julia> convert(AbstractArray{Float32}, cx)
3×4 JLArray{Float32, 2}:
 1.0  0.0  0.0  0.0
 0.0  1.0  0.0  1.0
 0.0  0.0  1.0  0.0

julia> x = onehotbatch(rand(1:99, 100), 1:100);

julia> @btime Matrix($x);
  2.375 μs (4 allocations: 10.12 KiB)
```
Unchanged is the need for `@allowscalar` in order to get a column:
```julia
julia> @allowscalar cx[:,4]
3-element OneHotVector(::UInt32) with eltype Bool:
 ⋅
 1
 ⋅

julia> cx[:,4]
ERROR: Scalar indexing is disallowed.
```