### PR TITLE
add missing mul! methods with transpose

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OneHotArrays"
 uuid = "0b1bfda6-eb8a-41d2-88d8-f5af5cad476f"
-version = "0.2.8"
+version = "0.2.9"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/test/gpu.jl
+++ b/test/gpu.jl
@@ -48,13 +48,14 @@ end
   y = onehotbatch(ones(3), 1:2) |> cu;
   @test (repr("text/plain", y); true)
 
-  gA = rand(3, 2) |> cu;
-
   #NOTE: this would require something that can compute gradient... we don't have that here?
   #@test gradient(A -> sum(A * y), gA)[1] isa CuArray
 end
 
 @testset "LinearAlgebra" begin
+  y = onehotbatch(ones(3), 1:2) |> cu;
+  gA = rand(3, 2) |> cu;
+
   # some specialized implementations call only mul! and not *, so we must ensure this works
   @test LinearAlgebra.mul!(similar(gA, 3, 3), gA, y) ≈ gA*y
   @test LinearAlgebra.mul!(similar(gA, 3, 1), gA, onehot(1, 1:2)) ≈ gA*onehot(1, 1:2)

--- a/test/gpu.jl
+++ b/test/gpu.jl
@@ -42,6 +42,14 @@ end
   @test Array{Float32}(cx) == Array{Float32}(x) == collect(x)
   @test convert(AbstractArray{Float32}, cx) isa CuArray{Float32}
   @test collect(convert(AbstractArray{Float32}, cx)) == collect(x)
+
+  A = cu([1 3 5; 2 4 6; 3 6 9])
+  b3_dense = cu(Array(OneHotMatrix([1, 1, 2], 4)))
+  b3 = OneHotMatrix(cu([1, 1, 2]), 4)
+
+  d1 = fill(NaN, 3, 4) |> cu
+  @test mul!(d1, A, b3') == A * b3_dense'
+  @test mul!(d1, A, transpose(b3)) == A * transpose(b3_dense)
 end
 
 @testset "onehot gpu" begin

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -59,16 +59,36 @@ end
   c1 = fill(NaN, 3, 4)
   @test mul!(c1, A, b1) == A * b1
   @test c1 == A * b1
-  
+
   c4 = fill(NaN, 3, 6)
   @test mul!(c4, A, b4) == A * b4  # b4 is reshaped but still one-hot
   @test mul!(c4, A', b4) == A' * b4
   c6 = fill(NaN, 3, 4)
   @test mul!(c6, A, b6) == A * b6  # b4 is reshaped and not one-hot
   @test mul!(c6, A', b6) == A' * b6
-  
+ 
   @test_throws DimensionMismatch mul!(c1, A, b2)
   @test_throws DimensionMismatch mul!(c1, A, b4)
   @test_throws DimensionMismatch mul!(c4, A, b1)
   @test_throws DimensionMismatch mul!(zeros(10, 3), A, b1)
+
+  # note that we have separate implementations for a couple of mul! for the time being
+
+  d1 = fill(NaN, 3, 4)
+  @test mul!(d1, A, b3') == A * Array(b3')
+  @test mul!(d1, A, transpose(b3)) == A * Array(transpose(b3))
+
+  d2 = fill(NaN, 3, 6)
+  @test mul!(d2, A, b5') == hcat(A[:,[1, 2, 3, 3]], A[:,1]+A[:,2], zeros(Int64, 3))
+  @test mul!(d2, A, transpose(b5)) == hcat(A[:,[1, 2, 3, 3]], A[:,1]+A[:,2], zeros(Int64, 3))
+
+  d3 = fill(NaN, 3, 6)
+  @test mul!(d3, A, b7') == A[:,[1, 2, 3, 1, 2, 3]]
+  @test mul!(d3, A, transpose(b7)) == A[:,[1, 2, 3, 1, 2, 3]]
+
+  d4 = fill(NaN, 4, 4)
+  @test_throws DimensionMismatch mul!(d4, A, b3')
+  @test_throws DimensionMismatch mul!(d4, A, transpose(b3))
+  @test_throws DimensionMismatch mul!(d1, fill(1, (4,4)), b3')
+  @test_throws DimensionMismatch mul!(d1, fill(1, (4,4)), transpose(b3))
 end


### PR DESCRIPTION
This adds the missing `mul!` methods that break the initial (minimal) example in #55.  The `*` method now falls back to this instead of having a separate definition with mutating `NNlib.scatter`.

It is undoubtedly inefficient to make a separate call to `fill!` before executing the `NNlib` kernel, but I have verified that `NNlib` already does this, so this shouldn't be any different than using `scatter`.

### PR Checklist

- [x] Tests are added
- [x] Documentation, if applicable
