### PR TITLE
Update Buildkite pipeline for the new JuliaGPU cluster

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,8 +8,7 @@ steps:
           version: "1.10"
       - JuliaCI/julia-test#v1: ~
     agents:
-      queue: "juliagpu"
-      cuda: "*"
+      queue: "cuda"
     timeout_in_minutes: 60
 
   - label: "GPU integration with julia v1"
@@ -20,8 +19,7 @@ steps:
       - JuliaCI/julia-coverage#v1:
           codecov: true
     agents:
-      queue: "juliagpu"
-      cuda: "*"
+      queue: "cuda"
     env:
       JULIA_CUDA_USE_BINARYBUILDER: "true"
     timeout_in_minutes: 60
@@ -32,8 +30,7 @@ steps:
   #         version: "nightly"
   #     - JuliaCI/julia-test#v1: ~
   #   agents:
-  #     queue: "juliagpu"
-  #     cuda: "*"
+  #     queue: "cuda"
   #   timeout_in_minutes: 60
 
 env:


### PR DESCRIPTION
The JuliaGPU Buildkite agents have moved to a dedicated cluster, where the single `juliagpu` queue has been split into per-backend queues. Steps now select agents using `queue: "cuda"`, `queue: "rocm"` or `queue: "oneapi"` instead of `queue: "juliagpu"` combined with a `cuda`/`rocm`/`intel` tag.

This change only affects agent selection; the steps themselves are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)